### PR TITLE
Update toolbar.tsx to remove dublicate tooltips in toggles icons

### DIFF
--- a/src/plugins/toolbar/primitives/toolbar.tsx
+++ b/src/plugins/toolbar/primitives/toolbar.tsx
@@ -94,7 +94,7 @@ export const ToggleSingleGroupWithItem = React.forwardRef<
       value={on ? 'on' : 'off'}
       ref={forwardedRef}
     >
-      <ToolbarToggleItem title={title} value="on" disabled={disabled}>
+      <ToolbarToggleItem aria-label={title} value="on" disabled={disabled}>
         <TooltipWrap title={title}>{children}</TooltipWrap>
       </ToolbarToggleItem>
     </RadixToolbar.ToggleGroup>


### PR DESCRIPTION
for the bold/italic/underline toggles , both ToolbarToggleItem and TooltipWrap has the title being passed, resulting in both the tooltip from redux + the native html tooltip 

Image example:
![CleanShot 2025-04-17 at 16 57 11@2x](https://github.com/user-attachments/assets/11b204a6-5734-4104-bc0a-8ffdadfdf002)
